### PR TITLE
A Guideline before installing CLI

### DIFF
--- a/Using-the-CLI.md
+++ b/Using-the-CLI.md
@@ -2,7 +2,7 @@
 
 Run `sudo npm install -g grunt-cli`.
 
-The `grunt` command-line interface comes with a series of options. Use `grunt -h` from your terminal to show these options.
+The `grunt` command-line interface comes with a series of options (You may only need to use sudo (for OSX, *nix, BSD etc)). Use `grunt -h` from your terminal to show these options.
 
 ### --help, -h
 Display help text


### PR DESCRIPTION
A line saying that the sudo should be applied for OSX, *nix, BSD users, like mentioned in the getting started page of grunt
http://gruntjs.com/getting-started  would be preferable for non-linux users as such.
